### PR TITLE
fix: run release script through bash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           VERSION="${CFST_VERSION#v}"
           export CFST_VERSION="$VERSION"
-          ./scripts/build-release.sh "${{ matrix.target }}"
+          bash ./scripts/build-release.sh "${{ matrix.target }}"
 
       - name: Upload desktop asset
         uses: actions/upload-artifact@v4
@@ -129,7 +129,7 @@ jobs:
         run: |
           VERSION="${CFST_VERSION#v}"
           export CFST_VERSION="$VERSION"
-          ./scripts/build-release.sh android
+          bash ./scripts/build-release.sh android
 
       - name: Upload Android asset
         uses: actions/upload-artifact@v4
@@ -176,7 +176,7 @@ jobs:
         env:
           CFST_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          ./scripts/build-release.sh manifest
+          bash ./scripts/build-release.sh manifest
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Run release helper with explicit bash in GitHub Actions so it does not depend on executable file mode.
- Applies to desktop, Android, and manifest generation steps.

## Validation
- bash -n scripts/build-release.sh scripts/build-android-mobile.sh
- Parsed .github/workflows/release.yml with python/yaml
- git diff --check

## Notes
- The first v1.0.0 release run also failed Android at Decode Android keystore because CFST_ANDROID_KEYSTORE_BASE64 is not configured in repository secrets.